### PR TITLE
Remove unsupported files

### DIFF
--- a/primestg/report/reports.py
+++ b/primestg/report/reports.py
@@ -6,8 +6,9 @@ from primestg.report.base import (
 from primestg.message import MessageS
 import sys
 
-SUPPORTED_REPORTS = ['S02', 'S04', 'S05', 'S06', 'S09', 'S12', 'S13', 'S15',
-                     'S17', 'S23', 'S24', 'S27']
+SUPPORTED_REPORTS = {
+    'S02', 'S04', 'S05', 'S06', 'S09', 'S12', 'S13', 'S15', 'S17'
+}
 
 
 def is_supported(report_code):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='primestg',
-    version='2019.10.21',
+    version='2019.10.22',
     packages=find_packages(),
     url='https://github.com/gisce/primestg',
     license='GNU Affero General Public License v3',


### PR DESCRIPTION
As part of [#1658](https://projectes.elgas.es/issues/1658)

This PR will remove the S23, S24 and S27 from the supported files on prime as we don't have any function to process them.